### PR TITLE
feat: add `-h` flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gabrielg2020/goto/cmd/pkg"
 	gotoPkg "github.com/gabrielg2020/goto/cmd/pkg"
 )
 
@@ -23,13 +24,17 @@ func main() {
 	}
 
 	// Define flags
-	maxDepth := flag.Int("d", config.MaxDepth, "Maximum depth to search")
+	maxDepth := flag.Int("d", config.MaxDepth, "Maximum depth to search") // -d flag
+	flag.Usage = func() {                                                 // -h flag
+		fmt.Fprintf(os.Stderr, "%s\n", pkg.Usage())
+	}
+
 	flag.Parse()
 
 	// Remaining arguments
 	args := flag.Args()
 	if len(args) == 0 {
-		fmt.Println("Please provide a pattern")
+		flag.Usage()
 		return
 	}
 	pattern := args[0]

--- a/cmd/pkg/utils.go
+++ b/cmd/pkg/utils.go
@@ -1,0 +1,10 @@
+package pkg
+
+// Returns the usage message
+func Usage() string {
+	return `Usage: goto [options] <pattern>
+Options:
+	-d <depth> Specify the maximum depth to search (default: 5)
+	-h         Display this help message
+`
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,17 +97,18 @@ goto src
 
 ## Options
 
-| Option | Description |
+| Option      | Description                           |
 | ----------- | ------------------------------------- |
-| `-d` | Specify maximum search depth. |
+| `-d`        | Specify maximum search depth.         |
+| `-h`        | Display help message.                 |
 | `<pattern>` | Fuzzy search pattern for directories. |
 
 ---
 
 ## Error Messages
 
-| Error Code | Description |
-| ----------- | ------------------------------------- |
+| Error Code   | Description  |
+| ------------ |  ----------- |
 | Coming Soon! | Coming Soon! |
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,17 +14,18 @@ goto src
 
 ## Options
 
-| Option | Description |
+| Option      | Description                           |
 | ----------- | ------------------------------------- |
-| `-d` | Specify maximum search depth. |
+| `-d`        | Specify maximum search depth.         |
+| `-h`        | Display help message.                 |
 | `<pattern>` | Fuzzy search pattern for directories. |
 
 ---
 
 ## Error Messages
 
-| Error Code | Description |
-| ----------- | ------------------------------------- |
+| Error Code   | Description  |
+| ------------ |  ----------- |
 | Coming Soon! | Coming Soon! |
 
 


### PR DESCRIPTION
## Description
Create `-h` flag to display help

### Help text
```
Usage: goto [options] <pattern>
Options:
	-d <depth> Specify the maximum depth to search (default: 5)
	-h         Display this help message
```
## Checklist
- [x] I have performed a self-review of my code.
- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.